### PR TITLE
Add basic Flutter blog app example

### DIFF
--- a/flutter_blog_app/README.md
+++ b/flutter_blog_app/README.md
@@ -1,0 +1,11 @@
+# Flutter Blog App
+
+This is a minimal example of a blog application built with Flutter. It shows a list of hardcoded posts and a detail page for each post.
+
+## Getting Started
+
+1. Install Flutter from [flutter.dev](https://flutter.dev).
+2. Run `flutter pub get` in this directory to fetch dependencies.
+3. Run the app with `flutter run`.
+
+This example is intentionally simple and uses in-memory data. It can be extended with a backend or local database for full blogging functionality.

--- a/flutter_blog_app/lib/main.dart
+++ b/flutter_blog_app/lib/main.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const BlogApp());
+}
+
+class BlogApp extends StatelessWidget {
+  const BlogApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Blog App',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const PostListPage(),
+    );
+  }
+}
+
+class Post {
+  final String title;
+  final String body;
+
+  Post({required this.title, required this.body});
+}
+
+final List<Post> demoPosts = [
+  Post(title: 'Hello World', body: 'Welcome to my blog!'),
+  Post(title: 'Second Post', body: 'More content here.'),
+  Post(title: 'Flutter Tips', body: 'Using Flutter for building apps.'),
+];
+
+class PostListPage extends StatelessWidget {
+  const PostListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Blog Posts')),
+      body: ListView.builder(
+        itemCount: demoPosts.length,
+        itemBuilder: (context, index) {
+          final post = demoPosts[index];
+          return ListTile(
+            title: Text(post.title),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PostDetailPage(post: post),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class PostDetailPage extends StatelessWidget {
+  final Post post;
+
+  const PostDetailPage({Key? key, required this.post}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(post.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(post.body),
+      ),
+    );
+  }
+}

--- a/flutter_blog_app/pubspec.yaml
+++ b/flutter_blog_app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: flutter_blog_app
+description: A simple blog app built with Flutter.
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a minimal Flutter blog example with a list of posts
- include README instructions for running the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b179f3b8c8329bdafd021dfcf7bab