### PR TITLE
Add Flutter Pomodoro timer example

### DIFF
--- a/flutter_pomodoro_app/README.md
+++ b/flutter_pomodoro_app/README.md
@@ -1,0 +1,11 @@
+# Flutter Pomodoro App
+
+This is a minimal Pomodoro timer built with Flutter. It starts with a 25 minute countdown that can be started, paused and reset.
+
+## Getting Started
+
+1. Install Flutter from [flutter.dev](https://flutter.dev).
+2. Run `flutter pub get` in this directory to fetch dependencies.
+3. Start the app with `flutter run`.
+
+This example is intentionally simple and keeps state in memory. You can extend it with notifications, persistent state or custom work/break intervals.

--- a/flutter_pomodoro_app/lib/main.dart
+++ b/flutter_pomodoro_app/lib/main.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const PomodoroApp());
+}
+
+class PomodoroApp extends StatelessWidget {
+  const PomodoroApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Pomodoro Timer',
+      theme: ThemeData(primarySwatch: Colors.red),
+      home: const PomodoroHomePage(),
+    );
+  }
+}
+
+class PomodoroHomePage extends StatefulWidget {
+  const PomodoroHomePage({Key? key}) : super(key: key);
+
+  @override
+  State<PomodoroHomePage> createState() => _PomodoroHomePageState();
+}
+
+class _PomodoroHomePageState extends State<PomodoroHomePage> {
+  static const int _initialMinutes = 25;
+  int _secondsLeft = _initialMinutes * 60;
+  Timer? _timer;
+
+  void _startTimer() {
+    if (_timer != null) return;
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_secondsLeft == 0) {
+        timer.cancel();
+        _timer = null;
+      } else {
+        setState(() => _secondsLeft--);
+      }
+    });
+  }
+
+  void _pauseTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _resetTimer() {
+    _pauseTimer();
+    setState(() => _secondsLeft = _initialMinutes * 60);
+  }
+
+  String get _timeDisplay {
+    final minutes = (_secondsLeft ~/ 60).toString().padLeft(2, '0');
+    final seconds = (_secondsLeft % 60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pomodoro Timer')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_timeDisplay, style: const TextStyle(fontSize: 48)),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                  onPressed: _startTimer,
+                  child: const Text('Start'),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: _pauseTimer,
+                  child: const Text('Pause'),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: _resetTimer,
+                  child: const Text('Reset'),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_pomodoro_app/pubspec.yaml
+++ b/flutter_pomodoro_app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: flutter_pomodoro_app
+description: A simple Pomodoro timer built with Flutter.
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a new Flutter project `flutter_pomodoro_app`
- implement a minimal Pomodoro timer
- document how to run the example

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdb65a8208329bc2d5fa7b3d3a64f